### PR TITLE
pack segwit version 0 only

### DIFF
--- a/counterpartylib/lib/address.py
+++ b/counterpartylib/lib/address.py
@@ -15,7 +15,7 @@ def pack(address):
             bech32 = bitcoin.bech32.CBech32Data(address)
             witver = (0x80 + bech32.witver).to_bytes(1, byteorder='big') # mark the first byte for segwit
             witprog = bech32.to_bytes()
-            if not (0 <= bech32.witver <= 16):
+            if bech32.witver != 0:
                 raise Exception('impossible witness version')
             if len(witprog) == 20:
                 return b''.join([witver, witprog])

--- a/counterpartylib/lib/address.py
+++ b/counterpartylib/lib/address.py
@@ -19,7 +19,6 @@ def pack(address):
                 raise Exception('impossible witness version')
             if bech32.witver != 0:
                 raise Exception('supported witness version 0 only for sending')
-                raise Exception('impossible witness version')
             if len(witprog) == 20:
                 return b''.join([witver, witprog])
             elif len(witprog) == 32:

--- a/counterpartylib/lib/address.py
+++ b/counterpartylib/lib/address.py
@@ -15,7 +15,10 @@ def pack(address):
             bech32 = bitcoin.bech32.CBech32Data(address)
             witver = (0x80 + bech32.witver).to_bytes(1, byteorder='big') # mark the first byte for segwit
             witprog = bech32.to_bytes()
+            if not (0 <= bech32.witver <= 16):
+                raise Exception('impossible witness version')
             if bech32.witver != 0:
+                raise Exception('supported witness version 0 only for sending')
                 raise Exception('impossible witness version')
             if len(witprog) == 20:
                 return b''.join([witver, witprog])


### PR DESCRIPTION
The length of the witprog of  taproot address(witness version1) may cause a accident.
Would you like to pass only version 0 for the time being?

ref.https://github.com/monaparty/counterparty-lib/pull/37